### PR TITLE
Update tomcat and webapp-runner deps for Java 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,25 +32,25 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-servlet-api</artifactId>
-            <version>7.0.42</version>
+            <version>7.0.57</version>
             <scope>provided</scope>
         </dependency>
         <dependency> <!-- otherwise pulled in by jsimone-webapp-runner -->
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jasper-el</artifactId>
-            <version>7.0.42</version>
+            <version>7.0.57</version>
             <scope>provided</scope>
         </dependency>
         <dependency> <!-- otherwise pulled in by jsimone-webapp-runner -->
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-jsp-api</artifactId>
-            <version>7.0.42</version>
+            <version>7.0.57</version>
             <scope>provided</scope>
         </dependency>
         <dependency> <!-- otherwise pulled in by jsimone-webapp-runner -->
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-el-api</artifactId>
-            <version>7.0.42</version>
+            <version>7.0.57</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.github.jsimone</groupId>
             <artifactId>webapp-runner</artifactId>
-            <version>7.0.34.0</version>
+            <version>7.0.57.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I'm evaluating proctor and I was unable to get this app to work with Java 8 without updating these dependencies.